### PR TITLE
Allows using multiple schedules for a particular class

### DIFF
--- a/lib/sidekiq/schedulable.rb
+++ b/lib/sidekiq/schedulable.rb
@@ -8,7 +8,7 @@ module Sidekiq
       def sidekiq_schedule(schedule, options = {})
         SidekiqSchedulable.schedules[self.to_s] = {
           worker: self,
-          cron: schedule,
+          crons: Array(schedule),
           options: options
         }
       end

--- a/lib/sidekiq_schedulable/schedule.rb
+++ b/lib/sidekiq_schedulable/schedule.rb
@@ -3,15 +3,17 @@ require 'parse-cron'
 module SidekiqSchedulable
   module Schedule
     def self.enqueue(schedule, last_run = nil)
-      return unless schedule[:cron]
+      return if schedule[:crons].empty?
 
       worker = schedule[:worker]
-      time = next_time(schedule[:cron])
-      if schedule[:options][:last_run]
-        last_time = last_run || last_time(schedule[:cron])
-        worker.perform_at(time, last_time.to_f)
-      else
-        worker.perform_at(time)
+      schedule[:crons].each do |cron|
+        time = next_time(cron)
+        if schedule[:options][:last_run]
+          last_time = last_run || last_time(cron)
+          worker.perform_at(time, last_time.to_f)
+        else
+          worker.perform_at(time)
+        end
       end
     end
 

--- a/lib/sidekiq_schedulable/version.rb
+++ b/lib/sidekiq_schedulable/version.rb
@@ -1,3 +1,3 @@
 module SidekiqSchedulable
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
This change allows multiple crons to be defined on the same class, resulting in multiple scheduled jobs. The use case for this pull request comes from a system which would like to run a reporting class twice on days with heavy load, and only once on typical days.
