### PR TITLE
Require sidekiq/api

### DIFF
--- a/lib/sidekiq_schedulable.rb
+++ b/lib/sidekiq_schedulable.rb
@@ -1,4 +1,5 @@
 require 'sidekiq'
+require 'sidekiq/api'
 require 'sidekiq/schedulable'
 require 'sidekiq_schedulable/startup'
 require 'sidekiq_schedulable/middleware/server'


### PR DESCRIPTION
Not sure which specific version of Sidekiq changed this. In sidekiq 4 and 5 the following occurs during boot:

```
NameError: uninitialized constant Sidekiq::ScheduledSet
.../gems/sidekiq_schedulable-0.1.1/lib/sidekiq_schedulable.rb:23:in `block in boot!'
```